### PR TITLE
Updated example to point to renamed SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
     </a>
 </p>
 
-# Example applications built on the digi.me JavaScript SDK.
-This repository contains example applications built on the [digi.me JavaScript SDK](https://github.com/digime/digime-sdk-js/). There are two example applications in this repository. One showcases private sharing, and the other showcasing postbox. You can find out more able both of these in our [documentation](https://digime.github.io/digime-sdk-js/pages/guides/start.html).
+# Example applications built on the digi.me Node.js SDK.
+This repository contains example applications built on the [digi.me Node.js SDK](https://github.com/digime/digime-sdk-nodejs/). There are two example applications in this repository. One showcases private sharing, and the other showcasing postbox. You can find out more able both of these in our [documentation](https://digime.github.io/digime-sdk-nodejs/pages/guides/start.html).
 
 ## Preparation
 
@@ -21,9 +21,9 @@ This repository contains example applications built on the [digi.me JavaScript S
 * git (optional)
 
 ## Installation
-1. [Download](https://github.com/digime/digime-js-sdk-example/archive/master.zip) and extract, or clone the `master` branch on this repo with the following command:
+1. [Download](https://github.com/digime/digime-sdk-nodejs-example/archive/master.zip) and extract, or clone the `master` branch on this repo with the following command:
 
-    `git clone https://github.com/digime/digime-js-sdk-example.git`
+    `git clone https://github.com/digime/digime-sdk-nodejs-example.git`
 
 2. In your terminal, navigate to the directory where you cloned/extracted this example (If you see this README in it, you're in the correct place!)
 
@@ -83,4 +83,4 @@ To run the application, please run the command: `npm start:write-example`
 
 ## Checking out our SDK
 
-This example was built upon the digi.me JavaScript SDK. You can find more information [here](https://github.com/digime/digime-sdk-js/).
+This example was built upon the digi.me Node.js SDK. You can find more information [here](https://github.com/digime/digime-sdk-nodejs-example/).

--- a/examples/read-data/index.js
+++ b/examples/read-data/index.js
@@ -16,7 +16,7 @@ app.use(express.static(__dirname + "/assets"));
 
 // Options that we will pass to the digi.me SDK
 // Visit https://go.digi.me/developers/register to get your Application ID
-// Replace [PLACEHOLDER_APP_ID] with the Application ID that was provided to you by digi.me
+// Replace "PLACEHOLDER_APP_ID" with the Application ID that was provided to you by digi.me
 const APP_ID = "PLACEHOLDER_APP_ID";
 
 // This object contains properties that are linked to the contract you're using.
@@ -36,7 +36,7 @@ const CONTRACT_DETAILS = {
 };
 
 // To initialize you can create the SDK like this:
-const { init } = require("@digime/digime-js-sdk");
+const { init } = require("@digime/digime-sdk-nodejs");
 const sdk = init({ applicationId: APP_ID });
 
 // In this route, we are presenting the user with an action that will take them to digi.me
@@ -71,7 +71,7 @@ app.get("/fetch", async (req, res) => {
   // callback - A callback if there are any errors. If successful, the redirect url linked to the contract will be used.
   // serviceId - 16 is the id of Spotify. You can replace this with the Service ID that you want to use.
   // To find out what services are available on digi.me:
-  // https://digime.github.io/digime-sdk-js/pages/fundamentals/available-services.html
+  // https://digime.github.io/digime-sdk-nodejs/pages/fundamentals/available-services.html
   // state - provide any information that can identify this user when authorization is complete.
   let authorizationOptions = {
     contractDetails: CONTRACT_DETAILS,

--- a/examples/write-data/index.js
+++ b/examples/write-data/index.js
@@ -15,7 +15,7 @@ app.use(express.static(__dirname + "/assets"));
 
 // Options that we will pass to the digi.me SDK
 // Visit https://go.digi.me/developers/register to get your Application ID
-// Replace [PLACEHOLDER_APP_ID] with the Application ID that was provided to you by digi.me
+// Replace "PLACEHOLDER_APP_ID" with the Application ID that was provided to you by digi.me
 const APP_ID = "PLACEHOLDER_APP_ID";
 
 // This object contains properties that are linked to the contract you're using.
@@ -36,7 +36,7 @@ const CONTRACT_DETAILS = {
 
 // To initialize you can create the SDK like this:
 // Only part required for initialization is the Application ID
-const { init } = require("@digime/digime-js-sdk");
+const { init } = require("@digime/digime-sdk-nodejs");
 const sdk = init({ applicationId: APP_ID });
 
 // In this route, we are presenting the user with an action that will take them to digi.me

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,13 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@digime/digime-js-sdk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@digime/digime-js-sdk/-/digime-js-sdk-5.0.0.tgz",
-      "integrity": "sha512-ceJTtr1zaCfZ2Sia4ik/vnr5JbXtz9/rDqIR6bHZXKGB6vVLg8tfdWZXPBnMQGYM3Mu5i/k9yNuPyN7mHLPixw==",
+    "@digime/digime-sdk-nodejs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@digime/digime-sdk-nodejs/-/digime-sdk-nodejs-5.1.0.tgz",
+      "integrity": "sha512-MQoEUOIhX2jS2IHjFjKQKEI16ValsBQEzCSn2iiBXZ7nYlLSI4Q0+ihrHhkmJjyMIVUX+QFtcYfYicXK0WN4Tw==",
       "requires": {
         "@types/node-rsa": "~1.1.0",
+        "@types/urijs": "~1.19.16",
         "base64url": "~3.0.1",
         "form-data": "~4.0.0",
         "fp-ts": "~2.10.5",
@@ -24,7 +25,8 @@
         "lodash.omit": "~4.5.0",
         "node-rsa": "~1.1.1",
         "pkg-dir": "~5.0.0",
-        "sprintf-js": "~1.1.2"
+        "sprintf-js": "~1.1.2",
+        "urijs": "~1.19.6"
       }
     },
     "@sindresorhus/is": {
@@ -33,17 +35,17 @@
       "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg=="
     },
     "@szmarczak/http-timer": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "requires": {
         "defer-to-connect": "^2.0.0"
       }
     },
     "@types/cacheable-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
+      "integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
       "requires": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "*",
@@ -52,9 +54,9 @@
       }
     },
     "@types/http-cache-semantics": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
     },
     "@types/ip": {
       "version": "1.1.0",
@@ -66,9 +68,9 @@
       }
     },
     "@types/keyv": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.2.tgz",
+      "integrity": "sha512-/FvAK2p4jQOaJ6CGDHJTqZcUtbZe820qIeTg7o0Shg7drB4JHeL+V/dhSaly7NXx6u8eSee+r7coT+yuJEvDLg==",
       "requires": {
         "@types/node": "*"
       }
@@ -79,9 +81,9 @@
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg=="
     },
     "@types/node-rsa": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node-rsa/-/node-rsa-1.1.0.tgz",
-      "integrity": "sha512-MDFFz1Fra3Xb4S7ZoWHPyFqq8WxRSI5c1Y/UKq/mD9HUAzGw9fu0LSgSvCzrqndtNPPw3DQS3petBVgQtPGfMA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node-rsa/-/node-rsa-1.1.1.tgz",
+      "integrity": "sha512-itzxtaBgk4OMbrCawVCvas934waMZWjW17v7EYgFVlfYS/cl0/P7KZdojWCq9SDJMI5cnLQLUP8ayhVCTY8TEg==",
       "requires": {
         "@types/node": "*"
       }
@@ -93,6 +95,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/urijs": {
+      "version": "1.19.16",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.16.tgz",
+      "integrity": "sha512-WgxqcUSEYijGnNWHSln/uqay+AywS3mEhLC+d2PwLsru2fLeMblvxP67Y/SCfB2Pxe+dX/zbIoNNzXY+VKOtNA=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -1075,6 +1082,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
+    },
+    "urijs": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ip": "~1.1.5"
   },
   "dependencies": {
-    "@digime/digime-js-sdk": "~5.0.0",
+    "@digime/digime-sdk-nodejs": "~5.1.0",
     "lodash.tonumber": "~4.0.3",
     "lodash.trimend": "~4.5.1",
     "shortid": "~2.2.16"


### PR DESCRIPTION
Staged changes to point to the renamed digi.me NodeJS SDK.
Updated to use v5.1.0 of `@digime/digime-sdk-nodejs`
