### PR TITLE
Updated to v6.0.0 of digime-sdk-nodejs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,15 @@
   "requires": true,
   "dependencies": {
     "@digime/digime-sdk-nodejs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@digime/digime-sdk-nodejs/-/digime-sdk-nodejs-5.1.0.tgz",
-      "integrity": "sha512-MQoEUOIhX2jS2IHjFjKQKEI16ValsBQEzCSn2iiBXZ7nYlLSI4Q0+ihrHhkmJjyMIVUX+QFtcYfYicXK0WN4Tw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@digime/digime-sdk-nodejs/-/digime-sdk-nodejs-6.0.0.tgz",
+      "integrity": "sha512-41si5MY8dDPNiJnt7617ITEKHBcD0l2TgV24rhn5sqWZz+E1pKSEloEi/UYVYi9WMNRcGIZTbkmN3Tkk64E9eA==",
       "requires": {
-        "@types/node-rsa": "~1.1.0",
-        "@types/urijs": "~1.19.16",
+        "@types/node-rsa": "~1.1.1",
+        "@types/urijs": "~1.19.17",
         "base64url": "~3.0.1",
         "form-data": "~4.0.0",
-        "fp-ts": "~2.10.5",
+        "fp-ts": "~2.11.3",
         "got": "~10.7.0",
         "io-ts": "~2.2.13",
         "jsonwebtoken": "~8.5.1",
@@ -68,9 +68,9 @@
       }
     },
     "@types/keyv": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.2.tgz",
-      "integrity": "sha512-/FvAK2p4jQOaJ6CGDHJTqZcUtbZe820qIeTg7o0Shg7drB4JHeL+V/dhSaly7NXx6u8eSee+r7coT+yuJEvDLg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.3.tgz",
+      "integrity": "sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==",
       "requires": {
         "@types/node": "*"
       }
@@ -97,9 +97,9 @@
       }
     },
     "@types/urijs": {
-      "version": "1.19.16",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.16.tgz",
-      "integrity": "sha512-WgxqcUSEYijGnNWHSln/uqay+AywS3mEhLC+d2PwLsru2fLeMblvxP67Y/SCfB2Pxe+dX/zbIoNNzXY+VKOtNA=="
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.17.tgz",
+      "integrity": "sha512-ShIlp+8iNGo/yVVfYFoNRqUiaE9wMCzsSl85qTg2/C5l56BTJokU7QeMgVBQ9xhcyhWQP0zGXPBZPPvEG/sRmQ=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -511,9 +511,9 @@
       "dev": true
     },
     "fp-ts": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.10.5.tgz",
-      "integrity": "sha512-X2KfTIV0cxIk3d7/2Pvp/pxL/xr2MV1WooyEzKtTWYSc1+52VF4YzjBTXqeOlSiZsPCxIBpDGfT9Dyo7WEY0DQ=="
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.3.tgz",
+      "integrity": "sha512-qHI5iaVSFNFmdl6yDensWfFMk32iafAINCnqx8m486DV1+Jht/bTnA9CyahL+Xm7h2y3erinviVBIAWvv5bPYw=="
     },
     "fresh": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ip": "~1.1.5"
   },
   "dependencies": {
-    "@digime/digime-sdk-nodejs": "~5.1.0",
+    "@digime/digime-sdk-nodejs": "~6.0.0",
     "lodash.tonumber": "~4.0.3",
     "lodash.trimend": "~4.5.1",
     "shortid": "~2.2.16"


### PR DESCRIPTION
This commit updates to use the latest v6.0.0 SDK from digi.me.
No breaking changes.